### PR TITLE
Added per_page parameter to the API request.

### DIFF
--- a/pelican_githubprojects/github.py
+++ b/pelican_githubprojects/github.py
@@ -37,7 +37,7 @@ from pelican import signals
 
 
 logger = logging.getLogger(__name__)
-GITHUB_API = "https://api.github.com/users/{username}/repos?type={user_type}&sort={sort_by}&direction={direction}"
+GITHUB_API = "https://api.github.com/users/{username}/repos?type={user_type}&sort={sort_by}&direction={direction}&per_page=200"  # per_page=200: maybe make this a plugin parameter
 
 
 class GithubProjects(object):


### PR DESCRIPTION
The plugin didn't show all my repos as they spanned over two pages. I solved this by adding per_page parameter (hard coded to 200 at this point) to the API request. It worked in my local copy of the plugin, but I didn't test this particular one-line pull request, so please test before merging.